### PR TITLE
More changes:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,11 @@ _build/html: Makefile
 
 upload: _build/html
 	echo upload
-	rsync  -ravzI -e ssh _build/html/* pandas@pandas.pydata.org:/usr/share/nginx/pandas/
+  # This requires that configure your ~/.ssh/config like
+  # Host pandas.pydata.org
+  # 	HostName <ip-addr>
+  # 	User <username>
+	rsync  -ravzI -e ssh _build/html/* pandas.pydata.org:/usr/share/nginx/pandas/
 
 .PHONY: help Makefile
 

--- a/_themes/pydata/layout.html
+++ b/_themes/pydata/layout.html
@@ -33,6 +33,16 @@
 <div class="sidebarblock">
 <h3>Versions</h3>
 
+{% if pre_release %}
+  <div class="tile" >
+      <h4>Release Candidate</h4>
+      {{ pre_release.version }} - {{ pre_release.date }} <br/>
+      <a href="https://pypi.org/project/pandas/{{ pre_release.version }}/#files">download</a> //
+      <a href="http://pandas.pydata.org/pandas-docs/version/{{ pre_release.version|strip_bugfix }}/">docs</a> //
+      <a href="http://pandas.pydata.org/pandas-docs/version/{{ pre_release.version|strip_bugfix }}/pandas.pdf">pdf</a>
+  </div>
+{% endif %}
+
 	<div class="tile">
 				<h4>Release</h4>
 				{{ releases[0].version }} - {{ releases[0].date}} <br/>
@@ -54,8 +64,8 @@
           <div>
               {{ release.version }} -
               <a href="https://pypi.org/project/pandas/{{ release.version }}/#files">download</a>          //
-              <a href="http://pandas.pydata.org/pandas-docs/version/{{ release.version }}/">docs</a> //
-              <a href="http://pandas.pydata.org/pandas-docs/version/{{ release.version }}/pandas.pdf">pdf</a>
+              <a href="http://pandas.pydata.org/pandas-docs/version/{{ release.version|strip_bugfix }}/">docs</a> //
+              <a href="http://pandas.pydata.org/pandas-docs/version/{{ release.version|strip_bugfix }}/pandas.pdf">pdf</a>
           </div>
 
       {% endfor %}

--- a/conf.py
+++ b/conf.py
@@ -17,8 +17,14 @@ import json
 with open("releases.json") as f:
     releases = json.load(f)
 
+
+with open("pre_release.json") as f:
+    pre = json.load(f)
+
+
 html_context = {
-    'releases': releases
+    'releases': releases,
+    'pre_release': pre,
 }
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -259,3 +265,19 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
+
+
+def strip_bugfix(value):
+    """Used in the sidebar to link to the latest minor version in a series"""
+    return '.'.join(value.split(".")[:-1])
+
+
+def add_jinja_filters(app):
+    app.builder.templates.environment.filters['strip_bugfix'] = strip_bugfix
+
+
+def setup(app):
+    '''
+    Adds extra jinja filters.
+    '''
+    app.connect("builder-inited", add_jinja_filters)

--- a/latest.rst
+++ b/latest.rst
@@ -1,5 +1,5 @@
 v0.21.0 RC1 (October 13, 2017)
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is a major release from 0.20.3 and includes a number of API
 changes, deprecations, new features, enhancements, and performance
@@ -9,7 +9,7 @@ all users upgrade to this version.
 Highlights include:
 
 * Integration with `Apache Parquet <https://parquet.apache.org/>`__,
-  including a new top-level read_parquet function and
+  including a new top-level ``read_parquet`` function and
   ``DataFrame.to_parquet`` method, see `here <https://pandas.pydata.org/pandas-docs/stable/io.html#io-parquet>`__
 
 * New user-facing pandas.api.types.CategoricalDtype for specifying

--- a/pre_release.json
+++ b/pre_release.json
@@ -1,0 +1,1 @@
+{"version": "0.21.0rc1", "date": "October 2017"}

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,5 @@
 [
-    {"version": "0.21.0rc1", "date": "October 2017"},
-    {"version": "0.20.3"},
+    {"version": "0.20.3", "date": "October 2017"},
     {"version": "0.19.2"},
     {"version": "0.18.1"},
     {"version": "0.17.1"},


### PR DESCRIPTION
1. Add sidebar section for pre-releases (which points to http://pandas.pydata.org/pandas-docs/version/0.21/)
2. Point sidebar links to 0.20/ instead of 0.20.latest

cc @jorisvandenbossche 